### PR TITLE
remove port from cookie domain

### DIFF
--- a/_js/_helper.js
+++ b/_js/_helper.js
@@ -62,7 +62,7 @@ export default class helper {
     }
 
     static urlHostTopLevel() {
-        let host = window.location.host;
+        let host = window.location.hostname;
         host = host.split('.');
         while (host.length > 2) {
             host.shift();


### PR DESCRIPTION
location.hostname is like location.host but without tcp port. 

Cookies on the same host are not distinguishable by ports, and doesn't work in many browsers (see https://stackoverflow.com/questions/1612177/are-http-cookies-port-specific)